### PR TITLE
Updated readme plus other goodies 

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -315,3 +315,7 @@ export class RemoteChromeWARCGenerator extends WARCWriterBase {
     generateWARC (capturer: RemoteChromeRequestCapturer, network: object, genOpts: WARCGenOpts): Promise<NullableEr>;
     generateWarcEntry (nreq: CDPRequestInfo, network: object): Promise<void>;
 }
+
+export class RequestLibWARCGenerator extends WARCWriterBase {
+    generateWarcEntry (resp: object): Promise<void>;
+}

--- a/lib/utils/url-helpers.js
+++ b/lib/utils/url-helpers.js
@@ -7,7 +7,7 @@ const { URL } = require('url')
  */
 function httpRequestPath (url) {
   if (!(url instanceof URL)) {
-    return httpRequestPath(new URL(url))
+    url = new URL(url)
   }
   return (
     `${url.pathname}${url.search ? `?${url.searchParams.toString()}` : ''}${url.hash ? url.hash : ''}`

--- a/lib/writers/electron.js
+++ b/lib/writers/electron.js
@@ -82,6 +82,12 @@ class ElectronWARCGenerator extends WARCWriterBase {
             replaceContentLen,
             `Content-Length: ${Buffer.byteLength(resData, 'utf8')}${CRLF}`
           )
+        } else {
+          // indicate that this record has 0 content
+          responseHeaders = responseHeaders.replace(
+            replaceContentLen,
+            `Content-Length: 0${CRLF}`
+          )
         }
       }
       return this.writeRequestResponseRecords(

--- a/lib/writers/puppeteer.js
+++ b/lib/writers/puppeteer.js
@@ -93,6 +93,12 @@ class PuppeteerWARCGenerator extends WARCWriterBase {
           replaceContentLen,
           `Content-Length: ${Buffer.byteLength(body, 'utf8')}${CRLF}`
         )
+      } else {
+        // indicate that this record has 0 content
+        resHTTP = resHTTP.replace(
+          replaceContentLen,
+          `Content-Length: 0${CRLF}`
+        )
       }
       return this.writeRequestResponseRecords(
         this._UP.href,

--- a/lib/writers/puppeteerCDP.js
+++ b/lib/writers/puppeteerCDP.js
@@ -84,6 +84,12 @@ class PuppeteerCDPWARCGenerator extends WARCWriterBase {
             replaceContentLen,
             `Content-Length: ${Buffer.byteLength(resData, 'utf8')}${CRLF}`
           )
+        } else {
+          // indicate that this record has 0 content
+          responseHeaders = responseHeaders.replace(
+            replaceContentLen,
+            `Content-Length: 0${CRLF}`
+          )
         }
       }
       return this.writeRequestResponseRecords(

--- a/lib/writers/remoteChrome.js
+++ b/lib/writers/remoteChrome.js
@@ -84,6 +84,12 @@ class RemoteChromeWARCGenerator extends WARCWriterBase {
             replaceContentLen,
             `Content-Length: ${Buffer.byteLength(resData, 'utf8')}${CRLF}`
           )
+        } else {
+          // indicate that this record has 0 content
+          responseHeaders = responseHeaders.replace(
+            replaceContentLen,
+            `Content-Length: 0${CRLF}`
+          )
         }
       }
       return this.writeRequestResponseRecords(

--- a/lib/writers/requestLib.js
+++ b/lib/writers/requestLib.js
@@ -20,28 +20,34 @@ const replaceContentLen = /Content-Length:.*\r\n/gi
 class RequestLibWARCGenerator extends WARCWriterBase {
   constructor () {
     super()
+    /**
+     * @type {URL}
+     * @private
+     */
     this._UP = new URL('about:blank')
   }
 
   /**
-   * Generates a WARC record. Needs the following request lib defaults:
+   * @desc Generates a WARC record. Needs the following request lib defaults:
    * rp.defaults({
    *   resolveWithFullResponse: true,
    *   simple: false
    * })
-   * @param {Request} resp
+   * @param {Object} resp
    * @returns {Promise<void>}
    */
   async generateWarcEntry (resp) {
     // generate the HTTP request to put in the WARC headers
     let reqHTTP = ''
-    this._UP.href = resp.request.href;
+    this._UP.href = resp.request.href
     if (this._UP.search !== '') {
-      reqHTTP += `${resp.request.method} ${this._UP.pathname}${this._UP.search[0]}${this._UP.searchParams} HTTP/1.1${CRLF}`
+      reqHTTP += `${resp.request.method} ${this._UP.pathname}${
+        this._UP.search[0]
+      }${this._UP.searchParams} HTTP/1.1${CRLF}`
     } else {
       reqHTTP += `${resp.request.method} ${this._UP.pathname} HTTP/1.1${CRLF}`
     }
-    reqHTTP += stringifyRequestHeaders(resp.request.headers, this._UP.host);
+    reqHTTP += stringifyRequestHeaders(resp.request.headers, this._UP.host)
 
     // if we made a POST request, make sure we have the content
     const pd = resp.request.method === 'POST' ? resp.request.body : null
@@ -62,12 +68,8 @@ class RequestLibWARCGenerator extends WARCWriterBase {
         `Content-Length: ${Buffer.byteLength(body, 'utf8')}${CRLF}`
       )
     } else {
-      // TODO: port into Puppeteer too!
       // indicate that this record has 0 content
-      resHTTP = resHTTP.replace(
-        replaceContentLen,
-        `Content-Length: 0${CRLF}`
-      )
+      resHTTP = resHTTP.replace(replaceContentLen, `Content-Length: 0${CRLF}`)
     }
     await this.writeResponseRecord(this._UP.href, resHTTP, body)
   }

--- a/lib/writers/warcWriterBase.js
+++ b/lib/writers/warcWriterBase.js
@@ -37,6 +37,7 @@ const WARCSepTSize = recordSeparatorBuffer.length + CRLFBuffer.length
  */
 function makeContentBuffer (string, maybeBuffer) {
   if (maybeBuffer != null) {
+    // ensure that the string buffer contains CRLF 2x since we have a body
     const strBuff = string.endsWith(CRLF2x)
       ? Buffer.from(string, 'utf8')
       : Buffer.from(`${string}${CRLF}`, 'utf8')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-warc",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "description": "Parse And Write Web Archive Records (WARC) Files",
   "main": "index.js",
   "author": {
@@ -17,13 +17,13 @@
   },
   "keywords": [
     "warc",
-    "warc.gz",
-    "warc-parsing",
-    "web-archiving",
-    "web archiving Electron",
-    "web archiving Chrome",
+    "warc parsing",
+    "warc creation",
+    "web archiving",
     "Electron",
-    "Chrome"
+    "Chrome",
+    "puppeteer",
+    "request"
   ],
   "engines": {
     "node": ">=8.0.0"
@@ -44,7 +44,6 @@
     }
   },
   "dependencies": {
-    "bluebird": "^3.5.3",
     "eventemitter3": "^3.1.0",
     "fs-extra": "^7.0.1",
     "lodash": "^4.17.11",


### PR DESCRIPTION
url-helpers.js: no longer go recursive just re-assign the url param if not an instance of URL
added rewriting the content-length of the response headers to zero when there was an error getting the response body (if not body then we are good anyways) to the WARC generator for electron, chrome and puppeteer(CDP)
updated index.d.ts with new class RequestLibWARCGenerator