### PR TITLE
Only callback once in WARCStreamTransform._flush

### DIFF
--- a/lib/parsers/warcStreamTransform.js
+++ b/lib/parsers/warcStreamTransform.js
@@ -110,8 +110,9 @@ class WARCStreamTransform extends Transform {
   _flush (done) {
     if (this.buffered) {
       this._consumeChunk(this.buffered, done, true)
+    } else {
+      done()
     }
-    done()
   }
 }
 


### PR DESCRIPTION
Calling `done()` in both `_consumeChunk` and `_flush` will cause an `ERR_MULTIPLE_CALLBACK` error.